### PR TITLE
When tag_name filter is given, uses release/tags API

### DIFF
--- a/src/github.coffee
+++ b/src/github.coffee
@@ -13,8 +13,16 @@ class GitHub extends Filters
   getReleases: (filter, callback) ->
     [callback, filter] = [filter, {}] if not callback? and filter instanceof Function
 
-    @callRepoApi 'releases', (error, releases) =>
+    urlPath = 'releases'
+    responseIsArray = true
+
+    if filter.tag_name?
+      urlPath += "/tags/#{filter.tag_name}"
+      responseIsArray = false
+
+    @callRepoApi urlPath, (error, releases) =>
       return callback(error) if error?
+      releases = [releases] unless responseIsArray
       callback null, @filter(releases, filter)
 
   # Public: Download the {asset}.


### PR DESCRIPTION
Refs https://github.com/atom/atom/issues/8525

This library doesn't currently account for pagination in GitHub's API. Now that Electron v0.22.0 is on the second page of results, many Atom builds are failing. This is a real quick fix: when filtering by tag, we use the `releases/tags` API so we don't have to deal w/ pagination.