### PR TITLE
Fix error while downloading behind proxy.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "minimatch": "0.2.12",
     "optimist": "~0.4.0",
     "prettyjson": "^1.1.3",
-    "request": "~2.27.0"
+    "request": "~2.51.0"
   },
   "devDependencies": {
     "grunt-contrib-coffee": "~0.6.6",


### PR DESCRIPTION
Fails download, behind proxy with node.js v0.12.7.
```
$ node --version
v0.12.7
$ npm --version
2.11.3
$ env | grep proxy
http_proxy=…
…
```

To test, for example, when I input 
```
$ ./bin/github-releases --tag=v0.35.4 --filename=electron-v0.35.4-linux-x64.zip download atom/electron --token <github access token>
_http_client.js:73
    throw new TypeError('Request path contains unescaped characters.');
          ^
TypeError: Request path contains unescaped characters.
    at new ClientRequest (_http_client.js:73:11)
    at TunnelingAgent.exports.request (http.js:49:10)
    at TunnelingAgent.createSocket (/home/user1/work/2015/fix-node12-proxy-failed/node_modules/request/node_modules/tunnel-agent/index.js:117:25)
    at TunnelingAgent.createSecureSocket [as createSocket] (/home/user1/work/2015/fix-node12-proxy-failed/node_modules/request/node_modules/tunnel-agent/index.js:184:41)
    at TunnelingAgent.addRequest (/home/user1/work/2015/fix-node12-proxy-failed/node_modules/request/node_modules/tunnel-agent/index.js:80:8)
    at new ClientRequest (_http_client.js:154:16)
    at Object.exports.request (http.js:49:10)
    at Object.exports.request (https.js:136:15)
    at Request.start (/home/user1/work/2015/fix-node12-proxy-failed/node_modules/request/request.js:584:30)
    at Request.end (/home/user1/work/2015/fix-node12-proxy-failed/node_modules/request/request.js:1212:28)
```

... After this patch ...

```
$ ./bin/github-releases --tag=v0.35.4 --filename=electron-v0.35.4-linux-x64.zip download atom/electron –token
... a file is downloaded ...
```

This issue is very similar to https://github.com/bower/registry-client/pull/20, you can see how the problem was fixed.
It seems this problem occurs with a combination of request@2.27.0 and node.js v0.12.7. It is resolved by using request@2.51.0.

